### PR TITLE
Fix connection leak

### DIFF
--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -151,18 +151,16 @@ func (c *Client) connectToEventHub(ctx context.Context) (*amqp.Client, string, e
 		return nil, "", err
 	}
 
-	addr := "amqps://" + c.creds.HostName
-	conn, err := amqp.Dial(addr, amqp.ConnSASLPlain(user, pass))
-	if err != nil {
-		return nil, "", err
+	addrDevice := "amqps://" + c.creds.HostName
+	connDevice, errDevice := amqp.Dial(addrDevice, amqp.ConnSASLPlain(user, pass))
+	if errDevice != nil {
+		return nil, "", errDevice
 	}
 	defer func() {
-		if err != nil {
-			conn.Close()
-		}
+		connDevice.Close()
 	}()
 
-	sess, err := conn.NewSession()
+	sess, err := connDevice.NewSession()
 	if err != nil {
 		return nil, "", err
 	}
@@ -189,8 +187,8 @@ func (c *Client) connectToEventHub(ctx context.Context) (*amqp.Client, string, e
 	group := rerr.RemoteError.Info["address"].(string)
 	group = group[strings.Index(group, ":5671/")+6 : len(group)-1]
 
-	addr = "amqps://" + rerr.RemoteError.Info["hostname"].(string)
-	conn, err = amqp.Dial(addr, amqp.ConnSASLPlain(c.creds.SharedAccessKeyName, c.creds.SharedAccessKey))
+	addr := "amqps://" + rerr.RemoteError.Info["hostname"].(string)
+	conn, err := amqp.Dial(addr, amqp.ConnSASLPlain(c.creds.SharedAccessKeyName, c.creds.SharedAccessKey))
 	if err != nil {
 		return nil, "", err
 	}

--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -151,16 +151,16 @@ func (c *Client) connectToEventHub(ctx context.Context) (*amqp.Client, string, e
 		return nil, "", err
 	}
 
-	addrDevice := "amqps://" + c.creds.HostName
-	connDevice, errDevice := amqp.Dial(addrDevice, amqp.ConnSASLPlain(user, pass))
-	if errDevice != nil {
-		return nil, "", errDevice
+	addr := "amqps://" + c.creds.HostName
+	conn, err := amqp.Dial(addr, amqp.ConnSASLPlain(user, pass))
+	if err != nil {
+		return nil, "", err
 	}
-	defer func() {
-		connDevice.Close()
-	}()
+	defer func(conn *amqp.Client) {
+		conn.Close()
+	}(conn)
 
-	sess, err := connDevice.NewSession()
+	sess, err := conn.NewSession()
 	if err != nil {
 		return nil, "", err
 	}
@@ -187,8 +187,8 @@ func (c *Client) connectToEventHub(ctx context.Context) (*amqp.Client, string, e
 	group := rerr.RemoteError.Info["address"].(string)
 	group = group[strings.Index(group, ":5671/")+6 : len(group)-1]
 
-	addr := "amqps://" + rerr.RemoteError.Info["hostname"].(string)
-	conn, err := amqp.Dial(addr, amqp.ConnSASLPlain(c.creds.SharedAccessKeyName, c.creds.SharedAccessKey))
+	addr = "amqps://" + rerr.RemoteError.Info["hostname"].(string)
+	conn, err = amqp.Dial(addr, amqp.ConnSASLPlain(c.creds.SharedAccessKeyName, c.creds.SharedAccessKey))
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
`connectToEventHub` function open two AMQP connection
- https://github.com/goautomotive/iothub/blob/5a80cb9a250d0ea0b6102bbc4878560ec307c65e/iotservice/client.go#L159
- https://github.com/goautomotive/iothub/blob/5a80cb9a250d0ea0b6102bbc4878560ec307c65e/iotservice/client.go#L197

But, It doesn't look like the first one gets closed on the success path.
This PR divides the variables.

See also: https://github.com/vcabbage/amqp/issues/115#issuecomment-408702364